### PR TITLE
Corrige le prefixe des ressources dans le service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,8 @@
 const CACHE = "ratp-vincennes-v1";
 self.addEventListener("install", e => {
-  e.waitUntil(caches.open(CACHE).then(c => c.addAll(["/", "/index.html", "/style.css", "/config.js", "/script.js", "/manifest.json"])));
+  const scope = self.registration.scope;
+  const files = ["", "index.html", "style.css", "config.js", "script.js", "manifest.json"].map(p => new URL(p, scope).href);
+  e.waitUntil(caches.open(CACHE).then(c => c.addAll(files)));
 });
 self.addEventListener("fetch", e => {
   if (e.request.method !== "GET") return;


### PR DESCRIPTION
## Summary
- utilise `self.registration.scope` pour composer les URLs en cache

## Testing
- `python -m py_compile script.py`
- `python -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686c28a2756c83339463f8438ade82c1