### PR TITLE
Màj README et workflows

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run script
         run: |
-          python first_last_rera_joinville.py --save-json data/today.json
+          python script.py
 
       - name: Commit & push if changed
         run: |

--- a/.github/workflows/update-rera-joinville.yml
+++ b/.github/workflows/update-rera-joinville.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Generate JSON
         run: |
           mkdir -p data
-          python first_last_rera_joinville.py --save-json data/today.json
+          python script.py
 
       - name: Commit & push if changed
         run: |

--- a/README.md
+++ b/README.md
@@ -1,25 +1,12 @@
 
 # RER A – Joinville‐le‐Pont : premiers et derniers trains
 
-Ce dépôt contient un script Python qui télécharge le GTFS Île‑de‑France Mobilités (via un *worker‑proxy* facultatif) et calcule les premiers et derniers passages du RER A à Joinville‑le‑Pont, dans les deux sens, pour la date de votre choix. Les dépendances nécessaires (**pandas**, **requests**) sont répertoriées dans `requirements.txt`.
+Ce dépôt contient un script Python (`script.py`) qui télécharge le GTFS Île‑de‑France Mobilités et calcule les prochains passages du RER A à Joinville‑le‑Pont, ainsi que les premiers et derniers trains théoriques. Les dépendances nécessaires (**pandas**, **requests**) sont répertoriées dans `requirements.txt`.
 
 ```bash
 pip install -r requirements.txt
-export IDFM_APIKEY="votre_cle_prim"
-# si nécessaire :
-export PROXY_WORKER="https://mon-worker.workers.dev/"
-
-python first_last_rera_joinville.py           # aujourd’hui
-python first_last_rera_joinville.py -d 2025-07-09
-python first_last_rera_joinville.py --save-json sortie.json
+python script.py
 ```
-
-## Variables d’environnement
-
-| Variable        | Rôle                                                             |
-|-----------------|------------------------------------------------------------------|
-| `IDFM_APIKEY`   | Jeton « données statiques » PRIM (obligatoire)                  |
-| `PROXY_WORKER`  | URL de votre worker Cloudflare servant de proxy (optionnel)     |
 
 ## Licence
 


### PR DESCRIPTION
## Summary
- mettre à jour la documentation pour expliquer l’usage de `script.py`
- remplacer l’appel à `first_last_rera_joinville.py` dans les workflows

## Testing
- `python3 -m py_compile script.py scripts/extract_rer_a_gtfs.py`
- `python3 script.py`

------
https://chatgpt.com/codex/tasks/task_e_686c3c9c20cc8333b4ca10da0b2a4cd7